### PR TITLE
use daemon threads in telemetryclient

### DIFF
--- a/telemetry/src/main/java/com/newrelic/telemetry/TelemetryClient.java
+++ b/telemetry/src/main/java/com/newrelic/telemetry/TelemetryClient.java
@@ -201,8 +201,8 @@ public class TelemetryClient {
         executor.shutdownNow();
       }
     } catch (InterruptedException e) {
-      Thread.currentThread().interrupt();
       LOG.error("interrupted graceful shutdown", e);
+      Thread.currentThread().interrupt();
     }
   }
 

--- a/telemetry/src/main/java/com/newrelic/telemetry/TelemetryClient.java
+++ b/telemetry/src/main/java/com/newrelic/telemetry/TelemetryClient.java
@@ -34,6 +34,7 @@ import org.slf4j.LoggerFactory;
 public class TelemetryClient {
 
   private static final Logger LOG = LoggerFactory.getLogger(TelemetryClient.class);
+  private static final long DEFAULT_SHUTDOWN_SECONDS = 3L;
 
   private final EventBatchSender eventBatchSender;
   private final MetricBatchSender metricBatchSender;
@@ -57,10 +58,7 @@ public class TelemetryClient {
       MetricBatchSender metricBatchSender,
       SpanBatchSender spanBatchSender,
       EventBatchSender eventBatchSender) {
-    this.metricBatchSender = metricBatchSender;
-    this.spanBatchSender = spanBatchSender;
-    this.eventBatchSender = eventBatchSender;
-    this.shutdownSeconds = 3L;
+    this(metricBatchSender, spanBatchSender, eventBatchSender, DEFAULT_SHUTDOWN_SECONDS);
   }
 
   /**
@@ -203,7 +201,8 @@ public class TelemetryClient {
         executor.shutdownNow();
       }
     } catch (InterruptedException e) {
-        LOG.error("interrupted graceful shutdown", e);
+      Thread.currentThread().interrupt();
+      LOG.error("interrupted graceful shutdown", e);
     }
   }
 

--- a/telemetry/src/main/java/com/newrelic/telemetry/TelemetryClient.java
+++ b/telemetry/src/main/java/com/newrelic/telemetry/TelemetryClient.java
@@ -43,7 +43,7 @@ public class TelemetryClient {
     thread.setDaemon(true);
     return thread;
   });
-  private final long shutdownSeconds = 3;
+  private final long shutdownSeconds;
 
   /**
    * Create a new TelemetryClient instance, with three senders. Note that if you don't intend to
@@ -60,6 +60,26 @@ public class TelemetryClient {
     this.metricBatchSender = metricBatchSender;
     this.spanBatchSender = spanBatchSender;
     this.eventBatchSender = eventBatchSender;
+    this.shutdownSeconds = 3L;
+  }
+
+  /**
+   * Create a new TelemetryClient instance, with three senders and seconds to wait for shutdown.
+   *
+   * @param metricBatchSender The sender for dimensional metrics.
+   * @param spanBatchSender The sender for distributed tracing spans.
+   * @param eventBatchSender The sender for custom events
+   * @param shutdownSeconds num of seconds to wait for graceful shutdown of its executor
+   */
+  public TelemetryClient(
+      MetricBatchSender metricBatchSender,
+      SpanBatchSender spanBatchSender,
+      EventBatchSender eventBatchSender,
+      long shutdownSeconds) {
+    this.metricBatchSender = metricBatchSender;
+    this.spanBatchSender = spanBatchSender;
+    this.eventBatchSender = eventBatchSender;
+    this.shutdownSeconds = shutdownSeconds;
   }
 
   /**

--- a/telemetry/src/main/java/com/newrelic/telemetry/TelemetryClient.java
+++ b/telemetry/src/main/java/com/newrelic/telemetry/TelemetryClient.java
@@ -43,6 +43,7 @@ public class TelemetryClient {
     thread.setDaemon(true);
     return thread;
   });
+  private final long shutdownSeconds = 3;
 
   /**
    * Create a new TelemetryClient instance, with three senders. Note that if you don't intend to
@@ -176,6 +177,14 @@ public class TelemetryClient {
   public void shutdown() {
     LOG.info("Shutting down the TelemetryClient background Executor");
     executor.shutdown();
+    try {
+      if (!executor.awaitTermination(shutdownSeconds, TimeUnit.SECONDS)) {
+        LOG.warn("couldn't shutdown within timeout");
+        executor.shutdownNow();
+      }
+    } catch (InterruptedException e) {
+        LOG.error("interrupted graceful shutdown", e);
+    }
   }
 
   /**

--- a/telemetry/src/main/java/com/newrelic/telemetry/TelemetryClient.java
+++ b/telemetry/src/main/java/com/newrelic/telemetry/TelemetryClient.java
@@ -38,7 +38,11 @@ public class TelemetryClient {
   private final EventBatchSender eventBatchSender;
   private final MetricBatchSender metricBatchSender;
   private final SpanBatchSender spanBatchSender;
-  private final ScheduledExecutorService executor = Executors.newSingleThreadScheduledExecutor();
+  private final ScheduledExecutorService executor = Executors.newSingleThreadScheduledExecutor(r -> {
+    Thread thread = new Thread(r);
+    thread.setDaemon(true);
+    return thread;
+  });
 
   /**
    * Create a new TelemetryClient instance, with three senders. Note that if you don't intend to


### PR DESCRIPTION
related issue: https://github.com/newrelic/newrelic-telemetry-sdk-java/issues/167

## Background
When TelemetryClient is getting 429 from NewRelic, it is caught into loop like below:

1. sendWithErrorHandling
2. retry
3. scheduleBatchSend
4. sendWithErrorHandling

In this flow, TelemetryClient doesn't consider maxRetries.

and this flow is executed in non-daemon threads(user threads), so while getting 429, TelemetryClient prevents JVM from shutting down.

This PR fixes the latter issue.

## Change
This PR just changes executor of TelemetryClient into one which uses ThreadFactory and set its threads as daemon threads.